### PR TITLE
Back to using AutoScalingGroupName as dimension

### DIFF
--- a/etc/checks/connections
+++ b/etc/checks/connections
@@ -5,7 +5,7 @@ metric_name="ConnectionsTotal"
 unit="Count"
 region=$1
 dimId="[ {\"Name\": \"InstanceId\", \"Value\": \"$2\"} ]"
-dimGr="[ {\"Name\": \"Group\", \"Value\": \"$3\"} ]"
+dimGr="[ {\"Name\": \"AutoScalingGroupName\", \"Value\": \"$3\"} ]"
 value=$(ss -a -t | wc -l)
 
 aws cloudwatch put-metric-data \

--- a/etc/checks/disk
+++ b/etc/checks/disk
@@ -5,7 +5,7 @@ unit="Percent"
 metric_name=
 region=$1
 dimId="[ {\"Name\": \"InstanceId\", \"Value\": \"$2\"} ]"
-dimGr="[ {\"Name\": \"Group\", \"Value\": \"$3\"} ]"
+dimGr="[ {\"Name\": \"AutoScalingGroupName\", \"Value\": \"$3\"} ]"
 value=
 
 info=$(df -x tmpfs -x devtmpfs | tail -n+2)

--- a/etc/checks/load
+++ b/etc/checks/load
@@ -5,7 +5,7 @@ metric_name="LoadAverage"
 unit="Count"
 region=$1
 dimId="[ {\"Name\": \"InstanceId\", \"Value\": \"$2\"} ]"
-dimGr="[ {\"Name\": \"Group\", \"Value\": \"$3\"} ]"
+dimGr="[ {\"Name\": \"AutoScalingGroupName\", \"Value\": \"$3\"} ]"
 value=$(cat /proc/loadavg |cut -d " " -f 1)
 
 aws cloudwatch put-metric-data \

--- a/etc/checks/memory
+++ b/etc/checks/memory
@@ -5,7 +5,7 @@ metric_name="MemoryUtilization"
 unit="Percent"
 region=$1
 dimId="[ {\"Name\": \"InstanceId\", \"Value\": \"$2\"} ]"
-dimGr="[ {\"Name\": \"Group\", \"Value\": \"$3\"} ]"
+dimGr="[ {\"Name\": \"AutoScalingGroupName\", \"Value\": \"$3\"} ]"
 value=
 
 total=$(free -m | grep "Mem" | tr -s " " | cut -d " " -f 2)

--- a/etc/cwput.conf
+++ b/etc/cwput.conf
@@ -5,7 +5,6 @@ stop on runlevel [016]
 
 script
   . /etc/profile
-  export CWPUT_GROUP
   while [ 1 ]
   do
     (HOME=/root timeout 120 /usr/bin/cwput.bash) &


### PR DESCRIPTION
This is the dimension used for built-in EC2 metrics dimensioned by ASG.  It is allowed to PUT to an arbitrary ASG, in case your stack does not have an ASG.
