### PR TITLE
Send all metrics in single API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ autoscaling group ID of instances metrics can be tracked both by individual
 instance IDs and by the AS group as a whole.
 
 If unset the second dimension will fallback to the instance ID.
+
+Set the `CWPUT_NAMESPACE` environment variable to submit metrics to CloudWatch
+using a namespace different from the cwput default of `System/Linux`

--- a/bin/cwput.bash
+++ b/bin/cwput.bash
@@ -1,24 +1,44 @@
 #!/usr/bin/env bash
 
-CONFIG_DIR="/etc/cwput/checks"
-INSTANCEID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
-REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed '$s/.$//')
-CWPUT_GROUP=${CWPUT_GROUP:-"$INSTANCEID"}
+CWPUT_NAMESPACE=${CWPUT_NAMESPACE:-"System/Linux"}
+CWPUT_CONFIG_DIR=${CWPUT_CONFIG_DIR:-"/etc/cwput/checks"}
+CWPUT_GROUP=${CWPUT_GROUP:-"$INSTANCE_ID"}
+CWPUT_DIM_ID=${CWPUT_DIM_ID:-"[ {\"Name\": \"InstanceId\", \"Value\": \"$INSTANCE_ID-$STACK_NAME-$EC2_REGION\"} ]"}
+CWPUT_DIM_GROUP=${CWPUT_DIM_GROUP:-"[ {\"Name\": \"AutoScalingGroupName\", \"Value\": \"$CWPUT_GROUP\"} ]"}
 
-if [ -z $INSTANCEID ]; then
+if [ -z $INSTANCE_ID ]; then
     echo "InstanceID could not be determined"
     exit 1
 fi
 
-if [ -z $REGION ]; then
+if [ -z $EC2_REGION ]; then
     echo "Region could not be determined"
     exit 1
 fi
 
-for file in $( ls $CONFIG_DIR );
+metrics=
+
+for file in $( ls $CWPUT_CONFIG_DIR );
 do
-    # timeout to avoid overlapping jobs in case of slow command
-    timeout 30 $CONFIG_DIR/$file $REGION $INSTANCEID-$STACK_NAME-$EC2_REGION $CWPUT_GROUP &
-    # Reduce load on instance and CloudWatch API request rate
-    sleep $[ ( $RANDOM % 6 )  + 1 ]
+    data=$($CWPUT_CONFIG_DIR/$file)
+    # A check may echo multiple lines, one per metric
+    for line in $data; do
+        if [ -n "$metrics" ]; then
+            metrics="$metrics,"
+        fi
+        metric_name=${line%%;*}
+        metric_name_and_unit=${line%;*}
+        unit=${metric_name_and_unit##*;}
+        value=${line##*;}
+        # Submit value for instance and for autoscaling group
+        part="{\"MetricName\": \"$metric_name\", \"Dimensions\": $CWPUT_DIM_ID, \"Value\": $value, \"Unit\": \"$unit\"}, \
+              {\"MetricName\": \"$metric_name\", \"Dimensions\": $CWPUT_DIM_GROUP, \"Value\": $value, \"Unit\": \"$unit\"}"
+
+        metrics="$metrics$part"
+    done
 done
+
+aws cloudwatch put-metric-data \
+--region $EC2_REGION \
+--namespace $CWPUT_NAMESPACE \
+--metric-data "[ $metrics ]"

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+### 0.6.0
+
+- Submits metrics to CloudWatch in batch
+- Checks can no longer set their own namespace
+
 ### 0.5.0
 
 - Adds support for awscli 1.5.x.

--- a/etc/checks/connections
+++ b/etc/checks/connections
@@ -2,19 +2,8 @@
 
 set -e
 
-namespace="System/Linux"
 metric_name="ConnectionsTotal"
 unit="Count"
-region=$1
-dimId="[ {\"Name\": \"InstanceId\", \"Value\": \"$2\"} ]"
-dimGr="[ {\"Name\": \"AutoScalingGroupName\", \"Value\": \"$3\"} ]"
 value=$(ss -a -t | wc -l)
 
-aws cloudwatch put-metric-data \
---region $region \
---namespace "$namespace" \
---metric-data "\
-[\
-{\"MetricName\": \"$metric_name\", \"Dimensions\": $dimId, \"Value\": $value, \"Unit\": \"$unit\"}, \
-{\"MetricName\": \"$metric_name\", \"Dimensions\": $dimGr, \"Value\": $value, \"Unit\": \"$unit\"}\
-]"
+echo "$metric_name;$unit;$value"

--- a/etc/checks/cpu
+++ b/etc/checks/cpu
@@ -2,21 +2,8 @@
 
 set -e
 
-namespace="System/Linux"
 metric_name="CPUUtilization"
 unit="Percent"
-region=$1
-dimId="[ {\"Name\": \"InstanceId\", \"Value\": \"$2\"} ]"
-dimGr="[ {\"Name\": \"AutoScalingGroupName\", \"Value\": \"$3\"} ]"
-value=
-
 value=$(echo $[100-$(vmstat|tail -1|awk '{print $15}')])
 
-aws cloudwatch put-metric-data \
---region $region \
---namespace "$namespace" \
---metric-data "\
-[\
-{\"MetricName\": \"$metric_name\", \"Dimensions\": $dimId, \"Value\": $value, \"Unit\": \"$unit\"}, \
-{\"MetricName\": \"$metric_name\", \"Dimensions\": $dimGr, \"Value\": $value, \"Unit\": \"$unit\"}\
-]"
+echo "$metric_name;$unit;$value"

--- a/etc/checks/disk
+++ b/etc/checks/disk
@@ -2,16 +2,8 @@
 
 set -e
 
-namespace="System/Linux"
 unit="Percent"
-metric_name=
-region=$1
-dimId="[ {\"Name\": \"InstanceId\", \"Value\": \"$2\"} ]"
-dimGr="[ {\"Name\": \"AutoScalingGroupName\", \"Value\": \"$3\"} ]"
-value=
-
 info=$(df -x tmpfs -x devtmpfs | tail -n+2)
-metrics=""
 
 while read line; do
     metric_name=
@@ -28,13 +20,6 @@ while read line; do
         metric_name="${mount}DiskUtilization"
     fi
 
-    metrics="$metrics,{\"MetricName\": \"$metric_name\", \"Dimensions\": $dimId, \"Value\": $value, \"Unit\": \"$unit\"}"
-    metrics="$metrics,{\"MetricName\": \"$metric_name\", \"Dimensions\": $dimGr, \"Value\": $value, \"Unit\": \"$unit\"}"
+    echo "$metric_name;$unit;$value"
+
 done <<< "$info"
-
-metrics=$(sed  's/^,//' <<< $metrics); # Strip leading comma
-
-aws cloudwatch put-metric-data \
---region $region \
---namespace "$namespace" \
---metric-data "[ $metrics ]"

--- a/etc/checks/load
+++ b/etc/checks/load
@@ -2,19 +2,8 @@
 
 set -e
 
-namespace="System/Linux"
 metric_name="LoadAverage"
 unit="Count"
-region=$1
-dimId="[ {\"Name\": \"InstanceId\", \"Value\": \"$2\"} ]"
-dimGr="[ {\"Name\": \"AutoScalingGroupName\", \"Value\": \"$3\"} ]"
 value=$(cat /proc/loadavg |cut -d " " -f 1)
 
-aws cloudwatch put-metric-data \
---region $region \
---namespace "$namespace" \
---metric-data "\
-[\
-{\"MetricName\": \"$metric_name\", \"Dimensions\": $dimId, \"Value\": $value, \"Unit\": \"$unit\"}, \
-{\"MetricName\": \"$metric_name\", \"Dimensions\": $dimGr, \"Value\": $value, \"Unit\": \"$unit\"}\
-]"
+echo "$metric_name;$unit;$value"

--- a/etc/checks/memory
+++ b/etc/checks/memory
@@ -2,23 +2,11 @@
 
 set -e
 
-namespace="System/Linux"
 metric_name="MemoryUtilization"
 unit="Percent"
-region=$1
-dimId="[ {\"Name\": \"InstanceId\", \"Value\": \"$2\"} ]"
-dimGr="[ {\"Name\": \"AutoScalingGroupName\", \"Value\": \"$3\"} ]"
-value=
 
 total=$(free -m | grep "Mem" | tr -s " " | cut -d " " -f 2)
 free=$(free -m | grep "buffers/cache" | tr -s " " | cut -d " " -f 4)
 value=$((100 - (( (($free * 100)) / $total)) ))
 
-aws cloudwatch put-metric-data \
---region $region \
---namespace "$namespace" \
---metric-data "\
-[\
-{\"MetricName\": \"$metric_name\", \"Dimensions\": $dimId, \"Value\": $value, \"Unit\": \"$unit\"}, \
-{\"MetricName\": \"$metric_name\", \"Dimensions\": $dimGr, \"Value\": $value, \"Unit\": \"$unit\"}\
-]"
+echo "$metric_name;$unit;$value"

--- a/etc/checks/networkin
+++ b/etc/checks/networkin
@@ -4,13 +4,8 @@ set -e
 
 CWPUT_NET=${CWPUT_NET:-"eth0"}
 
-namespace="System/Linux"
 metric_name="NetworkIn"
 unit="Bytes"
-region=$1
-dimId="[ {\"Name\": \"InstanceId\", \"Value\": \"$2\"} ]"
-dimGr="[ {\"Name\": \"AutoScalingGroupName\", \"Value\": \"$3\"} ]"
-value=
 
 rx=$(cat /sys/class/net/$CWPUT_NET/statistics/rx_bytes)
 
@@ -22,12 +17,5 @@ prev=$(cat /tmp/cwput_rx_bytes)
 
 value=$(($rx - $prev))
 echo "$rx" > /tmp/cwput_rx_bytes
-aws cloudwatch put-metric-data \
---region $region \
---namespace "$namespace" \
---metric-data "\
-[\
-{\"MetricName\": \"$metric_name\", \"Dimensions\": $dimId, \"Value\": $value, \"Unit\": \"$unit\"}, \
-{\"MetricName\": \"$metric_name\", \"Dimensions\": $dimGr, \"Value\": $value, \"Unit\": \"$unit\"}\
-]"
 
+echo "$metric_name;$unit;$value"

--- a/etc/checks/networkout
+++ b/etc/checks/networkout
@@ -4,13 +4,8 @@ set -e
 
 CWPUT_NET=${CWPUT_NET:-"eth0"}
 
-namespace="System/Linux"
 metric_name="NetworkOut"
 unit="Bytes"
-region=$1
-dimId="[ {\"Name\": \"InstanceId\", \"Value\": \"$2\"} ]"
-dimGr="[ {\"Name\": \"AutoScalingGroupName\", \"Value\": \"$3\"} ]"
-value=
 
 tx=$(cat /sys/class/net/$CWPUT_NET/statistics/tx_bytes)
 
@@ -22,12 +17,5 @@ prev=$(cat /tmp/cwput_tx_bytes)
 
 value=$(($tx - $prev))
 echo "$tx" > /tmp/cwput_tx_bytes
-aws cloudwatch put-metric-data \
---region $region \
---namespace "$namespace" \
---metric-data "\
-[\
-{\"MetricName\": \"$metric_name\", \"Dimensions\": $dimId, \"Value\": $value, \"Unit\": \"$unit\"}, \
-{\"MetricName\": \"$metric_name\", \"Dimensions\": $dimGr, \"Value\": $value, \"Unit\": \"$unit\"}\
-]"
 
+echo "$metric_name;$unit;$value"


### PR DESCRIPTION
Use a single call to PutMetricData to send all metrics to CloudWatch.  Reduces cost.  Sacrifice is that all metrics must be under a single namespace.
