### PR TITLE
Jitter and not detailed

### DIFF
--- a/bin/cwput.bash
+++ b/bin/cwput.bash
@@ -38,6 +38,9 @@ do
     done
 done
 
+# Jitter around API call to avoid rate limiting when running lots of EC2s
+sleep $[ ( $RANDOM % 8 )  + 1 ]
+
 aws cloudwatch put-metric-data \
 --region $EC2_REGION \
 --namespace $CWPUT_NAMESPACE \

--- a/etc/cwput.conf
+++ b/etc/cwput.conf
@@ -8,6 +8,10 @@ script
   while [ 1 ]
   do
     (HOME=/root timeout 120 /usr/bin/cwput.bash) &
-    sleep 60
+    if [ -n "$CWPUT_DISABLE_DETAILED" ]; then
+        sleep 300
+    else
+        sleep 60
+    fi
   done
 end script


### PR DESCRIPTION
- Adds jitter around the AWS API call, which reduces chance of hitting CloudWatch API limit
- Gives the option to set CWPUT_DISABLE_DETAILED in order to disable CloudWatch detailed monitoring